### PR TITLE
Adds resize observer to direct parent. Demo includes resizable section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,10 +84,11 @@
         margin: 0;
         padding: 0;
         margin: 0 auto;
+        min-width: 675px;
+        max-width: 850px;
+        resize: horizontal;
       }
       div.carousel-parent-wrapper {
-        margin: 5rem auto;
-        width: 90%;
         margin: 5rem auto;
         background-color: brown;
       }

--- a/src/Carousel.ts
+++ b/src/Carousel.ts
@@ -610,12 +610,16 @@ export default class Carousel {
     // Add the correct event listeners to the window for resizing the carousel based
     // on the resizing method.
     if (this.resizingMethod === "stretch-gap") {
-      window.addEventListener("resize", () => this.resizeGap());
+      new ResizeObserver(() => this.resizeGap()).observe(
+        this.carouselContainer.parentElement as HTMLElement
+      );
     } else if (
       this.resizingMethod === "stretch" ||
       this.resizingMethod == "stretch-scale"
     ) {
-      window.addEventListener("resize", () => this.resizeScale());
+      new ResizeObserver(() => this.resizeScale()).observe(
+        this.carouselContainer.parentElement as HTMLElement
+      );
     }
   }
 
@@ -696,7 +700,7 @@ export default class Carousel {
    * after a transition has ended.
    * @returns {void} Nothing.
    */
-  private transformCarouselItems(animate = true): void {
+  private transformCarouselItems(animate: boolean = true): void {
     // If the transform should not be animated, remove the transition property.
     if (!animate) {
       this.carouselItemContainer.style.transition = "none";


### PR DESCRIPTION
Closes #20.

Simple fix; replaces `resize` event listener with a `ResizeObserver` object on the direct parent of the carousel. Even carousels without any 'real' parent element (only within <HTML>) will resize with the <HTML> resizing.