### PR TITLE
Makes changes to always keep pointers within [0, length).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package_lock.json
 dist
+.DS_Store

--- a/index.html
+++ b/index.html
@@ -78,6 +78,14 @@
               <p>Red</p>
             </div>
           </div>
+          <div>1</div>
+          <div>2</div>
+          <div>3</div>
+          <div>4</div>
+          <div>5</div>
+          <div>6</div>
+          <div>7</div>
+          <div>8</div>
         </div>
       </div>
 

--- a/src/Carousel.ts
+++ b/src/Carousel.ts
@@ -246,11 +246,15 @@ export default class Carousel {
           // Indicate the scrolling direction.
           this.prevScrollDirection = "left";
 
+          // Reposition the pointers. If they become negative, they should
+          // roll over to the end of the carousel.
+          this.allCarouselItemsBottomPtr -= this.carouselScrollBy;
+          this.allCarouselItemsTopPtr -= this.carouselScrollBy;
+          this.adjustPointers();
+
           // Add the appropriate number of carousel items to the left side of the
           // carousel item container. These should be actual carousel items, not
           // dummy items.
-          this.allCarouselItemsBottomPtr -= this.carouselScrollBy;
-          this.allCarouselItemsTopPtr -= this.carouselScrollBy;
           const prevItems = this.getCarouselItems(
             this.carouselScrollBy,
             this.allCarouselItemsBottomPtr
@@ -300,8 +304,12 @@ export default class Carousel {
             this.allCarouselItemsTopPtr
           );
           this.carouselItemContainer.append(...nextItems);
+
+          // Reposition the pointers. If they become greater than the length of
+          // the carousel items, they should roll over to the beginning.
           this.allCarouselItemsBottomPtr += this.carouselScrollBy;
           this.allCarouselItemsTopPtr += this.carouselScrollBy;
+          this.adjustPointers();
 
           // Add the matching number of dummy items to the left side.
           const prevItems = this.getCarouselItems(
@@ -703,13 +711,6 @@ export default class Carousel {
       this.allCarouselItemsBottomPtr = (
         options as CarouselState
       ).allCarouselItemsBottomPtr;
-      if (this.allCarouselItems.length > 0) {
-        while (this.allCarouselItemsBottomPtr < 0) {
-          this.allCarouselItemsBottomPtr += this.allCarouselItems.length;
-        }
-      } else {
-        this.allCarouselItemsBottomPtr = 0;
-      }
     } else {
       this.allCarouselItemsBottomPtr = 0;
     }
@@ -912,6 +913,30 @@ export default class Carousel {
       )
     );
     this.carouselContainer.style.height = `${maxHeight}px`;
+  }
+
+  /**
+   * Adjusts the top and bottom pointers of the carousel items to be the correct
+   * values based on the current carousel position. Specifically, this method
+   * keeps the top and bottom pointers within the range of [0, length) so that
+   * when items are added or removed, the entire carousel is not shifted to one
+   * direction if the position comes after all of the elements on screen.
+   * @returns {void} Nothing.
+   */
+  private adjustPointers(): void {
+    while (this.allCarouselItemsBottomPtr >= this.allCarouselItems.length) {
+      this.allCarouselItemsBottomPtr -= this.allCarouselItems.length;
+    }
+    while (this.allCarouselItemsTopPtr >= this.allCarouselItems.length) {
+      this.allCarouselItemsTopPtr -= this.allCarouselItems.length;
+    }
+
+    while (this.allCarouselItemsBottomPtr < 0) {
+      this.allCarouselItemsBottomPtr += this.allCarouselItems.length;
+    }
+    while (this.allCarouselItemsTopPtr < 0) {
+      this.allCarouselItemsTopPtr += this.allCarouselItems.length;
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,10 +69,11 @@ const kingCrimson = new CarouselManager({
 });
 
 document.querySelector("button#add")?.addEventListener("click", () => {
-  kingCrimson.addCarouselItems(
-    [document.createElement("div"), document.createElement("div")],
-    2
-  );
+  const newItem1 = document.createElement("div");
+  newItem1.innerHTML = "New Item 1";
+  const newItem2 = document.createElement("div");
+  newItem2.innerHTML = "New Item 2";
+  kingCrimson.addCarouselItems([newItem1, newItem2]);
 });
 
 document.querySelector("button#remove")?.addEventListener("click", () => {


### PR DESCRIPTION
Closes #38.

A relatively simple fix has led to a few great additions to the code:
- When adding items, if the item is added to a position that comes after the current one, it will _not_ shift items over. This occurs if you loop back to the first item, then try adding an item to the end. Since the pointers to the right would extend out further, adding an item would push everything over. This no longer happens.
- The fix from #40 introduced to eliminate the infinite loop is no longer needed thanks to make sure that the bottom and top pointers are never outside of their valid ranges.