### PR TITLE
Partial fix to add/remove flashing on stretch-scale.

### DIFF
--- a/src/Carousel.ts
+++ b/src/Carousel.ts
@@ -479,7 +479,12 @@ export default class Carousel {
     this.allItems.forEach((carouselItem) => {
       // Set the width and height of the carousel items based on the constructor.
       carouselItem.style.width = `${this.itemWidth}px`;
-      carouselItem.style.height = `${this.itemHeight}px`;
+
+      // Source of adding and removing item flashing. Stretch-scale doesn't need
+      // to set an explicit height; the aspect ratio will be preserved.
+      if (this.resizingMethod !== "stretch-scale") {
+        carouselItem.style.height = `${this.itemHeight}px`;
+      }
 
       // The carousel items should by default not be allowed to shrink.
       carouselItem.style.flexShrink = "0";

--- a/webpages/test.html
+++ b/webpages/test.html
@@ -89,11 +89,8 @@
         </div>
       </div>
 
-      <button id="b1">1</button>
-      <button id="b2">2</button>
-      <button id="b3">Smart</button>
-      <button id="b4">None</button>
-      <button id="b5">5</button>
+      <button id="b1">Add Items</button>
+      <button id="b2">Remove Items</button>
     </section>
 
     <style>
@@ -103,6 +100,7 @@
       }
       body {
         overflow-y: scroll;
+        background-color: lightgray;
       }
       section {
         overflow: auto;


### PR DESCRIPTION
Closes #50.

The flashing is mostly gone when adding/removing items with `stretch-scale`. The only exception to this is if the container has fewer items in it than are visible, in which case adding or removing items creates a small visual bump. This can easily be avoided, however, if the client ensures that adding and removing do not create blank spots in their carousel.