### PR TITLE
Checks for same properties before updating carousel options.

### DIFF
--- a/src/CarouselManager.ts
+++ b/src/CarouselManager.ts
@@ -3,7 +3,7 @@ import CarouselOptions, {
   convertCarouselOptions,
   validateCarouselOptions,
 } from "./types/CarouselOptions.type.js";
-import CarouselState from "./types/CarouselState.type.js";
+import CarouselState, { equalStates } from "./types/CarouselState.type.js";
 
 /**
  * Class responsible for managing an instance of the Carousel class. Includes
@@ -40,6 +40,17 @@ export default class CarouselManager {
    * CarouselManager to call this method directly.
    */
   private changeCarouselOptions(options: CarouselOptions): Carousel {
+    // Don't do anything if the options are the same as the current carousel.
+    if (
+      this.carousel &&
+      equalStates(options as CarouselState, this.carousel.getCurrentState())
+    ) {
+      console.warn(
+        "The new Carousel options are the same as the current ones."
+      );
+      return this.carousel;
+    }
+
     // If the carousel is using stretch-populate, then the carousel manager
     // needs to check on each resize event to see if the carousel needs to
     // be re-initialized.
@@ -190,7 +201,7 @@ export default class CarouselManager {
     // Create a new carousel with the updated options.
     this.changeCarouselOptions({
       ...state,
-      carouselItems: state.carouselItems,
+      carouselItems: [...state.carouselItems],
     } as CarouselState);
   }
 
@@ -240,7 +251,7 @@ export default class CarouselManager {
     // Create a new carousel with the updated options.
     this.changeCarouselOptions({
       ...state,
-      carouselItems: state.carouselItems,
+      carouselItems: [...state.carouselItems],
     } as CarouselState);
   }
 }

--- a/src/types/CarouselState.type.ts
+++ b/src/types/CarouselState.type.ts
@@ -7,4 +7,43 @@ type CarouselState = CarouselOptions & {
   carouselContainer: HTMLElement;
 };
 
+/**
+ * Performs a deep equality check on two CarouselState objects. Returns true if they
+ * are equal and false otherwise.
+ * @param {CarouselState} state1 The first state object to compare.
+ * @param {CarouselState} state2 The second state object to compare.
+ * @returns {boolean} True if the two state objects are equal, false otherwise.
+ */
+export function equalStates(
+  state1: CarouselState,
+  state2: CarouselState
+): boolean {
+  return (
+    state1.containerID === state2.containerID &&
+    state1.itemWidth === state2.itemWidth &&
+    state1.itemHeight === state2.itemHeight &&
+    state1.itemSpacing === state2.itemSpacing &&
+    state1.buttonWidth === state2.buttonWidth &&
+    state1.buttonHeight === state2.buttonHeight &&
+    state1.buttonPosition === state2.buttonPosition &&
+    state1.numItemsVisible === state2.numItemsVisible &&
+    state1.scrollBy === state2.scrollBy &&
+    state1.transitionDuration === state2.transitionDuration &&
+    state1.transitionDelay === state2.transitionDelay &&
+    state1.transitionTimingFunction === state2.transitionTimingFunction &&
+    state1.scrollable === state2.scrollable &&
+    state1.autoScroll === state2.autoScroll &&
+    state1.autoScrollInterval === state2.autoScrollInterval &&
+    state1.autoScrollDirection === state2.autoScrollDirection &&
+    state1.autoScrollPauseOnHover === state2.autoScrollPauseOnHover &&
+    state1.syncScrollWithVisibility === state2.syncScrollWithVisibility &&
+    state1.resizingMethod === state2.resizingMethod &&
+    state1.wrappingMethod === state2.wrappingMethod &&
+    // Referential equality is sufficient for this property, since the
+    // carouseItems array, when adding or removing items, is always replaced
+    // with a new array.
+    state1.carouselItems === state2.carouselItems
+  );
+}
+
 export default CarouselState;

--- a/src/webpages/index.ts
+++ b/src/webpages/index.ts
@@ -76,8 +76,8 @@ const kingCrimson = new CarouselManager({
   buttonWidth: "20px",
   buttonHeight: "250px",
   buttonPosition: "center",
-  numItemsVisible: 5,
-  scrollBy: 4,
+  numItemsVisible: 1,
+  scrollBy: 1,
   containerID: "king-crimson",
   resizingMethod: "stretch-scale",
   transitionDuration: 500,
@@ -101,5 +101,5 @@ document.querySelector("button#b1")?.addEventListener("click", () => {
 });
 
 document.querySelector("button#b2")?.addEventListener("click", () => {
-  kingCrimson.removeCarouselItems(2);
+  kingCrimson.removeCarouselItems(0);
 });


### PR DESCRIPTION
Closes #32.

To avoid the allocation and deallocation of memory due to creating carousels that have the exact same properties, the `changeCarouselOptions()` method now checks to see if the new options are any different from the existing ones.

This meant that the `carouselItems` from the state needed to be put into their own array when adding or removing them, so that the reference would be seen as different by the new `equalStates()` function.