### PR TITLE
Fixes button style bugs.

### DIFF
--- a/src/Carousel.ts
+++ b/src/Carousel.ts
@@ -580,10 +580,8 @@ export default class Carousel {
     // Add the SVG icon to the button.
     carouselButton.innerHTML = `
     <svg
-      height="85.999px"
-      width="46.001px"
       fill="black"
-      style="enable-background: new 0 0 46.001 85.999; max-width: 60%; max-height: 60%;"
+      style="max-width: 60%; max-height: 60%;"
       viewBox="0 0 46.001 85.999"
     >
       ${


### PR DESCRIPTION
Closes #79, closes #80, closes #82.

- Prevents adding buttons to the DOM if the carousel is not scrollable. Makes sure that these buttons are not referenced (remove listeners, style, etc.) in order to prevent exceptions from being thrown.
- Sets a fixed margin and padding to ensure that global padding and margin changes do not impact the position of the chevron.
- Removes chevron SVG dimensions (takes dimensions of the path within) in order to vertically center the chevron within the button.
- Fixes the bug that caused auto-scroll carousels from not scrolling without specifying a direction explicitly. Now defaults to right.